### PR TITLE
bugfix/fix-save-many-to-many-values-being-unable-to-save-first-value

### DIFF
--- a/packages/crud/src/crud/saveManyToManyValues.ts
+++ b/packages/crud/src/crud/saveManyToManyValues.ts
@@ -14,7 +14,7 @@ const saveManyToManyValues = async (args) => {
       currentColumnName: `${module.table.name}_id`,
       opposingColumnName: `${relationalObjectKey}_id`,
       joinKey,
-      prevValueIds: item[joinKey].map((v) => v.id),
+      prevValueIds: item[joinKey]?.map((v) => v.id) || [],
       currentValueIds: value.map((v) => v.id),
     }
 


### PR DESCRIPTION
- fix: fix saveManytoManyValues being unable to save first value