### PR TITLE
Add count select for filters with foreign table

### DIFF
--- a/.changeset/fast-snails-develop.md
+++ b/.changeset/fast-snails-develop.md
@@ -1,0 +1,6 @@
+---
+"@gravis-os/query": patch
+"@gravis-os/types": patch
+---
+
+add count select for filter with foreign table

--- a/packages/query/src/query/useList.ts
+++ b/packages/query/src/query/useList.ts
@@ -315,11 +315,16 @@ export const getFetchListQueryFn = (props: UseListProps) => {
     // Setup query
     const query = supabaseClient
       .from(module.table.name)
-      .select(countOnly ? '*' : select || module?.select?.list || '*', {
-        // This is both the HEAD and GET query as this count gets overriden from above.
-        count: 'exact',
-        ...countProps,
-      })
+      .select(
+        countOnly
+          ? module?.select?.count || '*'
+          : select || module?.select?.list || '*',
+        {
+          // This is both the HEAD and GET query as this count gets overriden from above.
+          count: 'exact',
+          ...countProps,
+        }
+      )
 
     // Apply filters
     if (match) query.match(match)

--- a/packages/types/src/crud.ts
+++ b/packages/types/src/crud.ts
@@ -19,7 +19,7 @@ export interface CrudModule {
   name: { singular: string; plural: string }
   route?: { plural: string }
   table: { name: string; isJoinTable?: boolean }
-  select?: { detail?: string; list?: string }
+  select?: { detail?: string; list?: string; count?: string }
   Icon?: React.ElementType
   relations?: {
     [key: string]: {


### PR DESCRIPTION
For countOnly query, the select is always '*', so if there is a filter involving a foregin table e.g select(*)?company.title=ilike... it will return 400 due to missing embedded resources