### PR TITLE
Add disableEdit flag to disable fields in edit mode

### DIFF
--- a/.changeset/sixty-falcons-bake.md
+++ b/.changeset/sixty-falcons-bake.md
@@ -2,4 +2,4 @@
 "@gravis-os/form": patch
 ---
 
-add isImmutable flag to disable fields in edit mode
+add disableEdit flag to disable fields in edit mode

--- a/packages/form/src/form/FormSection/FormSection.tsx
+++ b/packages/form/src/form/FormSection/FormSection.tsx
@@ -43,7 +43,7 @@ export interface FormSectionProps extends Omit<CardProps, 'hidden'> {
     item?: CrudItem
   }>
 
-  isImmutable?: boolean
+  disableEdit?: boolean
   actionButtons?: ButtonProps[]
 
   disableCard?: boolean
@@ -75,7 +75,7 @@ const FormSection: React.FC<FormSectionProps> = (props) => {
     crudContext,
     userContext,
 
-    isImmutable,
+    disableEdit,
     ...rest
   } = props
   const { title } = rest
@@ -89,7 +89,7 @@ const FormSection: React.FC<FormSectionProps> = (props) => {
 
   // All FormSection fields are wrapped in a Grid container
   const shouldRenderReadOnlySection =
-    (isReadOnly || isImmutable) && renderReadOnlySection
+    (isReadOnly || disableEdit) && renderReadOnlySection
   const childrenJsx = shouldRenderReadOnlySection ? (
     renderReadOnlySection({ item, label: title })
   ) : (

--- a/packages/form/src/form/FormSection/renderField.tsx
+++ b/packages/form/src/form/FormSection/renderField.tsx
@@ -182,7 +182,7 @@ const renderField = (props: RenderFieldProps) => {
     isNew,
     isPreview,
     isReadOnly,
-    isImmutable,
+    disableEdit,
     item,
     disabledFields,
     renderReadOnly,
@@ -249,8 +249,11 @@ const renderField = (props: RenderFieldProps) => {
 
   // ==============================
   // Read Only Render
+  // In edit mode, isReadOnly is false, so for an immutable field,
+  // it will still stay uneditable with disableEdit flag
+  // If disableEdit is not specified, it has no effects
   // ==============================
-  if (isReadOnly || isImmutable) {
+  if (isReadOnly || disableEdit) {
     const label = injectedLabel || startCase(name)
 
     // Handle custom render
@@ -280,7 +283,7 @@ const renderField = (props: RenderFieldProps) => {
         const modelValue = get(item, modelName) || get(item, name)
 
         // Escape if no value found
-        if (!isImmutable && !isReadOnly && !modelValue) return null
+        if (!disableEdit && !isReadOnly && !modelValue) return null
         const getModelTitle = (value) =>
           get(
             value,

--- a/packages/form/src/form/FormSection/renderFieldWithWrapper.tsx
+++ b/packages/form/src/form/FormSection/renderFieldWithWrapper.tsx
@@ -36,7 +36,7 @@ export interface RenderFieldWithWrapperProps
 
 const renderFieldWithWrapper = (props: RenderFieldWithWrapperProps) => {
   const { formContext, sectionProps, fieldProps } = props
-  const { isNew, isPreview, item, isReadOnly, isImmutable } = sectionProps
+  const { isNew, isPreview, item, isReadOnly, disableEdit } = sectionProps
 
   /**
    * Handle Recursion case
@@ -80,7 +80,7 @@ const renderFieldWithWrapper = (props: RenderFieldWithWrapperProps) => {
             formContext,
             item,
             isNew,
-            isReadOnly: isReadOnly || isImmutable,
+            isReadOnly: isReadOnly || disableEdit,
             isPreview,
           }
         )}
@@ -120,7 +120,7 @@ const renderFieldWithWrapper = (props: RenderFieldWithWrapperProps) => {
     // Manage hidden fields with fieldEffect
     // TODO: Refactor to compose the wrappers with plugins instead
     children: isHidden
-      ? isReadOnly || isImmutable
+      ? isReadOnly || disableEdit
         ? null
         : fieldJsx
       : fieldJsxWithGrid,
@@ -133,7 +133,7 @@ const renderFieldWithWrapper = (props: RenderFieldWithWrapperProps) => {
   switch (true) {
     case hasFieldEffect:
       return <FieldEffectProvider {...fieldEffectProviderProps} />
-    case (isReadOnly || isImmutable) && isHidden:
+    case (isReadOnly || disableEdit) && isHidden:
       return null
     case isHidden:
       return fieldJsx


### PR DESCRIPTION
For invoices, all fields are not editable once its committed, except for status fields (status and payment status). This change allows status and payment status to still be editable after committing the invoice, while the rest stay uneditable