### PR TITLE
fix: client logos gallery dark mode

### DIFF
--- a/.changeset/quiet-sloths-hammer.md
+++ b/.changeset/quiet-sloths-hammer.md
@@ -1,0 +1,5 @@
+---
+"@gravis-os/landing": minor
+---
+
+fix bug where client logos gallery is still in dark mode when light mode selected

--- a/packages/landing/src/blocks/renderClientLogosGallery.tsx
+++ b/packages/landing/src/blocks/renderClientLogosGallery.tsx
@@ -12,7 +12,7 @@ const renderClientLogosGallery = (props: renderClientLogosGalleryProps) => {
     key: 'gallery',
     center: true,
     maxWidth: 'md',
-    dark: true,
+    invertImageOnMode: 'light',
     items: [
       { type: 'h4', title },
       {


### PR DESCRIPTION
Currently client logos gallery does not have a white background on light mode.