### PR TITLE
Add temp client for sign up to prevent global apiKey from being overidden

### DIFF
--- a/.changeset/long-teachers-work.md
+++ b/.changeset/long-teachers-work.md
@@ -1,0 +1,5 @@
+---
+"@gravis-os/auth": patch
+---
+
+add temp client for sign up

--- a/packages/auth/src/auth/SupabaseAuth.ts
+++ b/packages/auth/src/auth/SupabaseAuth.ts
@@ -1,6 +1,7 @@
 import { supabaseClient } from '@supabase/auth-helpers-nextjs'
 import toast from 'react-hot-toast'
 import { AuthUser } from '@gravis-os/types'
+import { createClient } from '@supabase/supabase-js'
 
 interface SupabaseAuthOptions {}
 
@@ -21,7 +22,11 @@ export const handleSignUp: HandleSignUp = async (
   const { email, password } = values
 
   try {
-    const onSignUp = await supabaseClient.auth.signUp(
+    const tempClient = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    )
+    const onSignUp = await tempClient.auth.signUp(
       {
         email: email?.toLowerCase(),
         password,

--- a/packages/auth/src/auth/SupabaseAuth.ts
+++ b/packages/auth/src/auth/SupabaseAuth.ts
@@ -22,6 +22,8 @@ export const handleSignUp: HandleSignUp = async (
   const { email, password } = values
 
   try {
+    // we use this to prevent the global supabaseClient
+    // from being overidden by NEXT_PUBLIC_SUPABASE_ANON_KEY
     const tempClient = createClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL,
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY


### PR DESCRIPTION
Note: enable RLS for user again once this is merged and wmc is updated