### PR TITLE
fix(fields): shrink select field when option value type is boolean.

### DIFF
--- a/.changeset/rotten-dolphins-clap.md
+++ b/.changeset/rotten-dolphins-clap.md
@@ -1,0 +1,5 @@
+---
+"@gravis-os/fields": minor
+---
+
+fix(fields): shrink select field when option value type is boolean.

--- a/packages/fields/src/fields/TextField.tsx
+++ b/packages/fields/src/fields/TextField.tsx
@@ -68,7 +68,11 @@ const TextField: React.FC<TextFieldProps> = (props) => {
     fullWidth: true,
     InputLabelProps: {
       ...InputLabelProps,
-      ...(!isNil(value) ? { shrink: Boolean(value) } : {}),
+      ...(!isNil(value)
+        ? {
+            shrink: typeof value === 'boolean' ? true : Boolean(value),
+          }
+        : {}),
     },
     sx: {
       ...sx,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Select TextField looks wired.

<img width="390" alt="Screenshot 2023-09-19 at 18 56 25" src="https://github.com/gravis-os/gravis-os/assets/128362586/34e59468-dd21-47d7-8e77-562251b45d11">


* **What is the new behavior (if this is a feature change)?**

<img width="390" alt="Screenshot 2023-09-19 at 18 58 09" src="https://github.com/gravis-os/gravis-os/assets/128362586/8a3997e6-9b98-4ece-9be3-a4b72577e186">


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

NA


* **Other information**:

NA
