### PR TITLE
feat(form): support to render custom files readonly section.

### DIFF
--- a/.changeset/brave-paws-cheer.md
+++ b/.changeset/brave-paws-cheer.md
@@ -1,0 +1,5 @@
+---
+"@gravis-os/form": minor
+---
+
+feat(form): support to render custom files readonly section.

--- a/packages/form/src/form/FormSection/renderField.tsx
+++ b/packages/form/src/form/FormSection/renderField.tsx
@@ -182,6 +182,18 @@ const renderField = (props: RenderFieldProps) => {
       case FormSectionFieldTypeEnum.IMAGES:
       case FormSectionFieldTypeEnum.FILES:
         const files = get(item, name)
+
+        if (hasRenderReadOnly) {
+          return renderReadOnly({
+            item,
+            name,
+            module,
+            label,
+            value: files,
+            title: label,
+          })
+        }
+
         const { bucketName } = fieldProps
         const FormSectionReadOnlyFiles = dynamic(() =>
           import('@gravis-os/fields').then(


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
`renderReadOnly` props not effect on files fields.


* **What is the new behavior (if this is a feature change)?**
can render the custom component in `renderReadOnly` props.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
NA


* **Other information**:
NA
