### PR TITLE
fix(auth): support to customize bg image style by passing backgroundImgProps.

### DIFF
--- a/.changeset/serious-buttons-notice.md
+++ b/.changeset/serious-buttons-notice.md
@@ -1,0 +1,5 @@
+---
+"@gravis-os/auth": minor
+---
+
+fix(auth): support to customize bg image style by passing backgroundImgProps.

--- a/packages/auth/src/auth/AuthLayout.tsx
+++ b/packages/auth/src/auth/AuthLayout.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react'
 import { StaticImageData } from 'next/image'
 import {
   Box,
-  BoxProps,
+  type BoxProps,
   Button,
   Card,
   Container,
@@ -10,6 +10,7 @@ import {
   Link,
   Grid,
   Image,
+  type ImageProps,
   Stack,
   Typography,
 } from '@gravis-os/ui'
@@ -27,6 +28,7 @@ export interface AuthLayoutProps extends BoxProps {
   logoProps?: BoxProps
   fullScreen?: boolean
   backgroundImgSrc?: string | StaticImageData
+  backgroundImgProps?: Omit<ImageProps, 'src'>
   copyright?: string | ReactNode
 }
 
@@ -43,6 +45,7 @@ const AuthLayout: React.FC<AuthLayoutProps> = (props) => {
     sx,
     fullScreen,
     backgroundImgSrc,
+    backgroundImgProps = {},
     copyright,
     ...rest
   } = props
@@ -101,7 +104,11 @@ const AuthLayout: React.FC<AuthLayoutProps> = (props) => {
           {/* Right Background */}
           {Boolean(backgroundImgSrc) && (
             <Grid item xs={false} md={5} sx={{ height: '100%' }}>
-              <Image src={backgroundImgSrc} boxSx={{ height: '100%', pb: 0 }} />
+              <Image
+                src={backgroundImgSrc}
+                boxSx={{ height: '100%', pb: 0 }}
+                {...backgroundImgProps}
+              />
             </Grid>
           )}
         </Grid>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
There's a default `ar` value which caused downstream apps UI issue.


* **What is the new behavior (if this is a feature change)?**
Support to pass `backgroundImgProps` to add `ar` manually when needed.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
NA


* **Other information**:
NA
