### PR TITLE
feat(form): add human readable date time format props.

### DIFF
--- a/.changeset/pretty-months-mix.md
+++ b/.changeset/pretty-months-mix.md
@@ -1,0 +1,5 @@
+---
+"@gravis-os/form": minor
+---
+
+feat(form): add human readable date time format props.

--- a/packages/form/src/form/FormSection/renderField.tsx
+++ b/packages/form/src/form/FormSection/renderField.tsx
@@ -57,14 +57,15 @@ const renderField = (props: RenderFieldProps) => {
     checkboxTableProps,
     chipFieldProps,
     fieldEffect,
+    formatDateTimeValue,
     gridProps,
     key,
-    modelFieldProps,
 
+    modelFieldProps,
     module,
     props: componentProps,
-    render,
 
+    render,
     type,
 
     ...rest
@@ -275,7 +276,9 @@ const renderField = (props: RenderFieldProps) => {
         )
       }
       default: {
-        const title = get(item, name)
+        const title = formatDateTimeValue
+          ? formatDateTimeValue(item)
+          : get(item, name)
 
         if (hasRenderReadOnly) {
           return renderReadOnly({

--- a/packages/form/src/form/FormSection/types.ts
+++ b/packages/form/src/form/FormSection/types.ts
@@ -82,9 +82,11 @@ export interface FormSectionFieldProps {
   // Not to be confused with `fieldProps` as that is from RHF.
   filterLabel?: string
 
+  formatDateTimeValue?: (item: CrudItem) => string
   // Manage layout
   gridProps?: GridProps
   helperText?: React.ReactNode
+
   // Manage state
   hidden?: FormSectionFieldBooleanFunction | boolean
 
@@ -92,13 +94,13 @@ export interface FormSectionFieldProps {
   key: string
 
   label?: string
-
   // Declares the column names of non-foreign keys on the related many-to-many table for saving
   manyToManyExtraColumnKeys?: string[]
   modelFieldProps?: Partial<ModelFieldProps>
   module?: CrudModule
   multiple?: boolean
   name: string
+
   // Filters
   op?: string
 
@@ -111,13 +113,13 @@ export interface FormSectionFieldProps {
 
   // This is for passing props to the underlying component field.
   props?: Record<string, any>
-
   // Render - manage custom renders for installing hooks
   render?: (props: {
     children: React.ReactNode
     formContext: UseFormReturn
   }) => any // Typings not working here should be React.ReactNode
   required?: boolean
+
   select?: any // Can either be MUI textfield select or react-query selector
 
   setFilterQuery?: (filter: [key: string, value: any]) => string[]
@@ -129,7 +131,6 @@ export interface FormSectionFieldProps {
 
   // Styling
   sx?: SxProps
-
   type?: FormSectionFieldTypeEnum | string // Should not have string type but adding so as to prevent having to TS casting downstream
   // withCreate function
   withCreate?: boolean


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
<img width="249" alt="Screenshot 2023-09-26 at 17 05 03" src="https://github.com/gravis-os/gravis-os/assets/128362586/0310f40a-4d1a-4896-8f76-86f02ec2486c">



* **What is the new behavior (if this is a feature change)?**
<img width="199" alt="Screenshot 2023-09-26 at 17 04 50" src="https://github.com/gravis-os/gravis-os/assets/128362586/ddd8eefd-ad86-4c3f-a17e-34272a50b027">



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Can do something like this if needed:
```js
delivery_at: {
    key: 'delivery_at',
    name: 'delivery_at',
    type: 'date_time',
    label: 'Delivery Date / Time',
    // new props
   formatDateTimeValue: (item) =>
      item?.delivery_at
        ? dayjs(item?.delivery_at).format('MM/DD/YYYY hh a')
        : '-',
  },
```


* **Other information**:
NA
