### PR TITLE
feat(form): add setTitle props to set custom form value.

### DIFF
--- a/.changeset/grumpy-humans-breathe.md
+++ b/.changeset/grumpy-humans-breathe.md
@@ -1,0 +1,5 @@
+---
+"@gravis-os/form": minor
+---
+
+fix(form): add setTitle props to set custom form value.

--- a/packages/form/src/form/FormSection/renderField.tsx
+++ b/packages/form/src/form/FormSection/renderField.tsx
@@ -64,7 +64,7 @@ const renderField = (props: RenderFieldProps) => {
     module,
     props: componentProps,
     render,
-
+    setTitle,
     type,
 
     ...rest
@@ -275,7 +275,7 @@ const renderField = (props: RenderFieldProps) => {
         )
       }
       default: {
-        const title = get(item, name)
+        const title = setTitle ? setTitle(item) : get(item, name)
 
         if (hasRenderReadOnly) {
           return renderReadOnly({

--- a/packages/form/src/form/FormSection/types.ts
+++ b/packages/form/src/form/FormSection/types.ts
@@ -122,6 +122,8 @@ export interface FormSectionFieldProps {
 
   setFilterQuery?: (filter: [key: string, value: any]) => string[]
 
+  setTitle?: (item: CrudItem) => string
+
   shouldQuillAutofocus?: boolean
 
   // Submission


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
<img width="249" alt="Screenshot 2023-09-26 at 17 05 03" src="https://github.com/gravis-os/gravis-os/assets/128362586/0310f40a-4d1a-4896-8f76-86f02ec2486c">



* **What is the new behavior (if this is a feature change)?**
<img width="199" alt="Screenshot 2023-09-26 at 17 04 50" src="https://github.com/gravis-os/gravis-os/assets/128362586/ddd8eefd-ad86-4c3f-a17e-34272a50b027">



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Can do something like this if needed:
```js
delivery_at: {
    key: 'delivery_at',
    name: 'delivery_at',
    type: 'date_time',
    label: 'Delivery Date / Time',
    // new props
    setTitle: (item) =>
      item?.delivery_at
        ? dayjs(item?.delivery_at).format('MM/DD/YYYY hh a')
        : '-',
  },
```


* **Other information**:
NA
