### PR TITLE
feat(form): applied renderReadOnlyField to default field.

### DIFF
--- a/.changeset/early-roses-brake.md
+++ b/.changeset/early-roses-brake.md
@@ -1,0 +1,5 @@
+---
+"@gravis-os/form": minor
+---
+
+feat(form): applied renderReadOnlyField to default field.

--- a/packages/form/src/form/FormSection/renderField.tsx
+++ b/packages/form/src/form/FormSection/renderField.tsx
@@ -60,10 +60,10 @@ const renderField = (props: RenderFieldProps) => {
     gridProps,
     key,
     modelFieldProps,
-    renderReadOnly: renderReadOnlyField,
     module,
     props: componentProps,
     render,
+    renderReadOnly: renderReadOnlyField,
     setTitle,
     type,
 
@@ -279,7 +279,7 @@ const renderField = (props: RenderFieldProps) => {
         const title = setTitle ? setTitle(item) : get(item, name)
 
         if (hasRenderReadOnly) {
-          return renderReadOnly({
+          return (renderReadOnly ?? renderReadOnlyField)({
             title,
             item,
             label,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
`renderReadOnlyField` only applied to `percentage` type input.


* **What is the new behavior (if this is a feature change)?**
applied `renderReadOnlyField` to default field.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
NA
