### PR TITLE
fix: json field value issue

### DIFF
--- a/.changeset/yellow-melons-battle.md
+++ b/.changeset/yellow-melons-battle.md
@@ -1,0 +1,5 @@
+---
+"@gravis-os/fields": patch
+---
+
+fix: json field value issue

--- a/packages/fields/src/fields/JsonField.tsx
+++ b/packages/fields/src/fields/JsonField.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Control, FieldValues, UseFormSetValue } from 'react-hook-form'
 import SyntaxHighlighter from 'react-syntax-highlighter'
 
@@ -181,8 +181,6 @@ export const JsonField: React.FC<JsonFieldProps> = (props) => {
   const toggleAdvancedEditMode = () =>
     setIsAdvancedEditMode(!isAdvancedEditMode)
 
-  const [objectValue, setObjectValue] = useState<Page['sections']>({})
-
   const getSectionsFromValue = (value: string) => {
     try {
       return JSON.parse(value)
@@ -190,6 +188,20 @@ export const JsonField: React.FC<JsonFieldProps> = (props) => {
       return {}
     }
   }
+
+  const stringValue = typeof value === 'string' ? value : JSON.stringify(value)
+  const objectValue =
+    typeof value === 'string' ? getSectionsFromValue(value) : value
+
+  const [advancedEditInput, setAdvancedEditInput] = useState(stringValue)
+
+  useEffect(() => {
+    const newObjectValue = getSectionsFromValue(advancedEditInput)
+    if (JSON.stringify(newObjectValue) === '{}') return
+    if (JSON.stringify(objectValue) !== JSON.stringify(newObjectValue)) {
+      setValue(name, newObjectValue)
+    }
+  }, [advancedEditInput])
 
   // Handle degenerate case
   if (objectValue === null)
@@ -205,7 +217,6 @@ export const JsonField: React.FC<JsonFieldProps> = (props) => {
       {isAdvancedEditMode ? (
         <div style={{ position: 'relative' }}>
           <TextField
-            {...props}
             inputProps={{
               sx: {
                 caretColor: 'black',
@@ -215,8 +226,9 @@ export const JsonField: React.FC<JsonFieldProps> = (props) => {
               },
             }}
             multiline
+            onChange={(e) => setAdvancedEditInput(e.currentTarget.value)}
             spellCheck="false"
-            value={typeof value === 'string' ? value : JSON.stringify(value)}
+            value={advancedEditInput}
           />
           <SyntaxHighlighter
             customStyle={{
@@ -238,7 +250,7 @@ export const JsonField: React.FC<JsonFieldProps> = (props) => {
             wrapLines
             wrapLongLines
           >
-            {typeof value === 'string' ? value : JSON.stringify(value)}
+            {advancedEditInput}
           </SyntaxHighlighter>
         </div>
       ) : (
@@ -246,8 +258,7 @@ export const JsonField: React.FC<JsonFieldProps> = (props) => {
           control,
           module,
           name,
-          sections:
-            typeof value === 'string' ? getSectionsFromValue(value) : value,
+          sections: objectValue,
           setValue,
         })
       )}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

fix

* **What is the current behavior?** (You can also link to an open issue here)

if saving while advanced edit is on, saves JSON sections in the database as a string value

* **What is the new behavior (if this is a feature change)?**

will save as an JSON object in any mode

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no