### PR TITLE
feat(crud): added defaultViewStyle props.

### DIFF
--- a/.changeset/wicked-steaks-run.md
+++ b/.changeset/wicked-steaks-run.md
@@ -1,0 +1,5 @@
+---
+"@gravis-os/crud": patch
+---
+
+feat(crud): added defaultViewStyle props.

--- a/packages/crud/src/crud/DataTable.tsx
+++ b/packages/crud/src/crud/DataTable.tsx
@@ -27,6 +27,7 @@ export interface DataTableProps extends AgGridProps {
   renderGridComponent?: RenderPropsFunction<{
     items
   }>
+  defaultViewStyle?: 'list' | 'grid'
   /**
    * To display the total row count
    */
@@ -65,6 +66,7 @@ const DataTable = React.forwardRef<
 
     module,
     renderGridComponent,
+    defaultViewStyle,
     rowData,
 
     // Server-side pagination
@@ -77,7 +79,7 @@ const DataTable = React.forwardRef<
     ...rest
   } = props
 
-  const [viewStyle, setViewStyle] = useState<'grid' | 'list'>('list')
+  const [viewStyle, setViewStyle] = useState<'grid' | 'list'>(defaultViewStyle ?? 'list')
 
   const [columnDefs, setColumnDefs] = useState(injectedColumnDefs)
   useEffect(() => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
default data table page view style is `list` style.


* **What is the new behavior (if this is a feature change)?**
can inject `view` style to data table component.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
NA
