### PR TITLE
fix: handle undefined values in form list

### DIFF
--- a/.changeset/slimy-icons-give.md
+++ b/.changeset/slimy-icons-give.md
@@ -1,0 +1,5 @@
+---
+"@gravis-os/form": patch
+---
+
+handle undefined values in form list values

--- a/packages/form/src/form/utils/withDbFormValues.ts
+++ b/packages/form/src/form/utils/withDbFormValues.ts
@@ -13,9 +13,11 @@ const getIdValuesWithRelationalKeysFromRelationalObjects = (values) => {
     if (Array.isArray(value) && !getIsArrayColumn(value)) {
       return {
         ...acc,
-        [key]: value.map((val) =>
-          getIdValuesWithRelationalKeysFromRelationalObjects(val)
-        ),
+        [key]: value
+          .filter(Boolean)
+          .map((val) =>
+            getIdValuesWithRelationalKeysFromRelationalObjects(val)
+          ),
       }
     }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

for list values in a form, undefined values are treated as objects in the map function and this throws an error

* **What is the new behavior (if this is a feature change)?**

filters out falsy values before passing it into the `getIdValuesWithRelationalKeysFromRelationalObjects` function.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no