### PR TITLE
feat(crud): added sx props into ag-grid columnDefs with avatar.

### DIFF
--- a/.changeset/tricky-items-hammer.md
+++ b/.changeset/tricky-items-hammer.md
@@ -1,0 +1,5 @@
+---
+"@gravis-os/crud": minor
+---
+
+feat(crud): added sx props support into ag-grid columnDef with avatar.

--- a/packages/crud/src/crud/useGetCrudTableColumnDefs/hocs/withPreview.tsx
+++ b/packages/crud/src/crud/useGetCrudTableColumnDefs/hocs/withPreview.tsx
@@ -59,7 +59,7 @@ const withPreview = (props) => {
         ...columnDef,
         cellRenderer: (params) => {
           // Show with avatar if avatar_src is present
-          const { hasAvatar } = columnDef
+          const { avatarSxProps, containerSxProps, hasAvatar } = columnDef
 
           const linkProps = {
             color: 'inherit',
@@ -80,12 +80,18 @@ const withPreview = (props) => {
           }
 
           return (
-            <Stack alignItems="center" direction="row" spacing={1}>
+            <Stack
+              alignItems="center"
+              direction="row"
+              spacing={1}
+              sx={containerSxProps}
+            >
               {hasAvatar && params.data && (
                 <StorageAvatar
                   alt={params.data.avatar_alt || params.data.title}
                   size={32}
                   src={params.data.avatar_src}
+                  sx={avatarSxProps}
                 />
               )}
               <Link {...linkProps}>{params.value}</Link>

--- a/packages/crud/src/types.ts
+++ b/packages/crud/src/types.ts
@@ -1,6 +1,8 @@
 import { ColDef } from 'ag-grid-community/dist/lib/entities/colDef'
 
 interface ExtendedCrudTableColumnDef {
+  avatarSxProps?: any
+  containerSxProps?: any
   hasAvatar?: boolean
   hasCheckboxSelection?: boolean
   hide?: (({ user }) => boolean) | boolean


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
No `sx` props support.


* **What is the new behavior (if this is a feature change)?**
added `avatarSxProps` and `containerSxProps` into `columnDef`.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
NIL


* **Other information**:

https://github.com/gravis-os/gravis-os/assets/128362586/fa608f1d-19ef-4d6d-ac61-bb4ff423ba5d

